### PR TITLE
correct cmake usage example in README.md

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,8 +10,6 @@ jobs:
       matrix:
         config:
         # https://github.com/actions/virtual-environments/tree/main/images/win
-        - { os: "windows-2016", vs: "Visual Studio 2017", arch: "x86" }
-        - { os: "windows-2016", vs: "Visual Studio 2017", arch: "x64" }
         - { os: "windows-2019", vs: "Visual Studio 2019", arch: "x86" }
         - { os: "windows-2019", vs: "Visual Studio 2019", arch: "x64" }
     name: "${{matrix.config.vs}} ${{matrix.config.arch}}"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Also, you can add the root repository directory to your [cmake](https://cmake.or
 
 ```cmake
 add_subdirectory(external/enum.hpp)
-target_link_libraries(your_project_target enum.hpp)
+target_link_libraries(your_project_target PUBLIC enum.hpp)
 ```
 
 ## Examples

--- a/untests/CMakeLists.txt
+++ b/untests/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 
 file(GLOB_RECURSE UNTESTS_SOURCES "*.cpp" "*.hpp")
 add_executable(${PROJECT_NAME} ${UNTESTS_SOURCES})
-target_link_libraries(${PROJECT_NAME} enum.hpp)
+target_link_libraries(${PROJECT_NAME} PUBLIC enum.hpp)
 
 target_compile_options(${PROJECT_NAME}
     PRIVATE


### PR DESCRIPTION
Modern CMake requires one of PRIVATE, PUBLIC, INTERFACE keywords. Otherwise the target_link_libraries degrades its behavior to old CMake and applies only linker flags instead of transitively forwarding all target requirements.